### PR TITLE
add page (#6)

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -54,6 +54,7 @@ module.exports = {
         let tagsA = $("ul li a")
         let paths = []
         let searchDataset = []
+        const pages = []
         tagsA.each((i, elem) => {
             let siblings = $(elem).siblings()
             let href = $(elem).attr("href")
@@ -73,6 +74,10 @@ module.exports = {
                     title: title,
                     input: this.config.doc.dir + href + ".md",
                     output: this.buildDir + href + ".html"
+                })
+                pages.push({
+                    title: title,
+                    href: this.rootPath + href + ".html",
                 })
             }
         })
@@ -140,6 +145,13 @@ module.exports = {
             this.data.__MARKDOWN_CONTENT__ = mdHtmlContent
             this.data.__CUR_TITLE__ = path.title
             this.data.__NAV_HTML__ = _$.html()
+
+            //get prev-page url and next-page url
+            const navIndex = pages.findIndex(item => item.title === path.title)
+            const prev = pages[navIndex - 1] 
+            const next = pages[navIndex + 1]
+            this.data.__PREV_PAGE_HREF__ = prev && prev.href
+            this.data.__NEXT_PAGE_HREF__ = next && next.href
 
             let htmlContent = ejs.render(this.themeBase, this.data)
             if ( this.config.theme.isMinify ) {

--- a/lib/themes/default/base.html
+++ b/lib/themes/default/base.html
@@ -55,6 +55,15 @@
                 <article class="markdown-body">
                     <%- __MARKDOWN_CONTENT__ %>
                 </article>
+                <!-- turn page -->
+                <div class="page">
+                    <% if (__PREV_PAGE_HREF__) { %>
+                        <a class="page-prev" href="<%- __PREV_PAGE_HREF__ %>">上一章</a>
+                    <% } %> 
+                    <% if (__NEXT_PAGE_HREF__) { %>
+                        <a class="page-next" href="<%- __NEXT_PAGE_HREF__ %>">下一章</a>
+                    <% } %> 
+                </div>
             </div>
         </div>
         <!-- up to top -->

--- a/lib/themes/default/static/css/mobile.css
+++ b/lib/themes/default/static/css/mobile.css
@@ -27,6 +27,9 @@
       padding: 5px 0;
       margin-top: 55px;
     }
+    .page{
+      padding: 30px 100px;
+    }
     .main .gotop{
       left: unset;
       right:32px;

--- a/lib/themes/default/static/css/style.css
+++ b/lib/themes/default/static/css/style.css
@@ -277,6 +277,27 @@ ul li a {
     opacity: 1;
 }
 
+.page{
+    max-width: 900px;
+    box-sizing: border-box;
+    padding: 30px 50px;
+    background: #fff;
+    overflow: hidden;
+}
+.page a{
+    color: #1890ff;
+    background-color: transparent;
+    border-color: transparent;
+    box-shadow: none;
+    text-decoration: none;
+}
+.page-prev {
+    float: left;
+}
+.page-next {
+    float: right;
+}
+
 .loading-warp {
     background-color: #fff;
     position: fixed;


### PR DESCRIPTION
## 问题

在手机上读文档时，翻看上一页、下一页的唯一入口是：调出左边导航栏，然后点击对应的文章。很不方便。

## 改进

在每一篇文档下方添加按钮：`上一页`、`下一页`。当前如果是第一页，则不显示 `上一页` 按钮，当前是最后一页时，不显示 `下一页`。

## 说明

已适配移动端。