### PR TITLE
编译成功后 process.exit(code) 状态码应为 0

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -43,7 +43,7 @@ module.exports = {
         utils.writeFile(this.buildDir + "/data.js", minifyJsCode)
         console.log(chalk.bgGreen(" DONE ") + " Compiled successfully.")
         if ( !this.options.dev ) {
-            process.exit(1)
+            process.exit(0)
         }
     },
 


### PR DESCRIPTION
参考 [这里](http://nodejs.cn/api/process/process_exit_code.html)，状态码0为成功，1为失败。此处应该为”成功“，否则会造成 [这个](https://github.com/teadocs/teadocs/issues/9#issuecomment-517172079) 后果。