### PR TITLE
feat: add article category (#8)

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -151,7 +151,12 @@ module.exports = {
             const prev = pages[navIndex - 1] 
             const next = pages[navIndex + 1]
             this.data.__PREV_PAGE_HREF__ = prev && prev.href
+            this.data.__PREV_PAGE_TITLE__ = prev && prev.title
             this.data.__NEXT_PAGE_HREF__ = next && next.href
+            this.data.__NEXT_PAGE_TITLE__ = next && next.title
+
+            //get article catalog html-str
+            this.data.__ARTICLE_CATALOG__ = this._geneArticleCatalog(mdHtmlContent)
 
             let htmlContent = ejs.render(this.themeBase, this.data)
             if ( this.config.theme.isMinify ) {
@@ -179,6 +184,34 @@ module.exports = {
         this._buildErrorPage(errorFrameHtml)
         //build search data
         this.writeSearchData(JSON.stringify(searchDataset))
+    },
+
+    _geneArticleCatalog(htmlContent) {
+        const $ = cheerio.load(htmlContent);
+    
+        let hArr = [], highestLvl, hNum = 0
+        $('h1, h2, h3, h4, h5, h6').each(function () {
+            hNum++
+            let lvl = $(this).get(0).tagName.substr(1)
+            if(!highestLvl) highestLvl = lvl
+            hArr.push({
+                lvl: lvl - highestLvl + 1,
+                content: $(this).find('span').text(),
+                id: $(this).attr('id')
+            })
+        })
+
+        $ul = '<ul class="toc-affix">'
+        hArr.forEach(h => {
+            $ul += `
+                <li class="toc-item text-elli" style="padding-left: ${h.lvl * 15}px" data-link="${h.id}">
+                    <a href="#${h.id}" title="${h.content}">${h.content}</a>
+                </li>
+            `
+        })
+        $ul += '</ul>'
+
+        return $ul;
     },
 
     _getParents($, node) {

--- a/lib/themes/default/base.html
+++ b/lib/themes/default/base.html
@@ -58,11 +58,22 @@
                 <!-- turn page -->
                 <div class="page">
                     <% if (__PREV_PAGE_HREF__) { %>
-                        <a class="page-prev" href="<%- __PREV_PAGE_HREF__ %>">上一章</a>
+                         <a class="page-prev" href="<%- __PREV_PAGE_HREF__ %>">
+                            <i class="fa fa-arrow-left" aria-hidden="true"></i>
+                            <%- __PREV_PAGE_TITLE__ %>
+                        </a>
                     <% } %> 
                     <% if (__NEXT_PAGE_HREF__) { %>
-                        <a class="page-next" href="<%- __NEXT_PAGE_HREF__ %>">下一章</a>
+                        <a class="page-next" href="<%- __NEXT_PAGE_HREF__ %>">
+                            <%- __NEXT_PAGE_TITLE__ %>
+                            <i class="fa fa-arrow-right" aria-hidden="true"></i>
+                        </a>
                     <% } %> 
+                </div>
+
+                <!-- article catalog -->
+                <div class="toc">
+                    <%- __ARTICLE_CATALOG__ %>
                 </div>
             </div>
         </div>

--- a/lib/themes/default/static/css/mobile.css
+++ b/lib/themes/default/static/css/mobile.css
@@ -1,129 +1,75 @@
-@media screen and (max-width: 414px) {
-    .main {
-      height: auto;
-    }
-    .main .tea-menu {
-      position: fixed;
-      /* display: none; */
-      left:-250px;
-      z-index: 999;
-      padding-top: 70px;
-    }
-    .main .tea-content {
-      width: 100%;
-      overflow: hidden;
-    }
-    .main .tea-nav {
-      position: fixed;
-      top: 0;
-      left: 0;
-      z-index: 9999;
-    }
-    .main .tea-nav h3 {
-      font-size: 18px !important;
-    }
-    .tea-container {
-      height: auto;
-      padding: 5px 0;
-      margin-top: 55px;
-    }
-    .page{
-      padding: 30px 100px;
-    }
-    .main .gotop{
-      left: unset;
-      right:32px;
-    }
-    #menu-mask {
-      display: none;
-      position: fixed;
-      left: 0;
-      right: 0;
-      top: 0;
-      bottom: 0;
-      margin: auto;
-      z-index: 998;
-      background: rgba(0, 0, 0, 0.5);
-    }
-    .mask .search-popup {
-      width: 100%;
-          height:100%;
-          border-radius: 0;
-    }
-    .mask .search-popup .search-popup-body {
-      max-height: 94%;
-    }
-    .mask .search-popup .search-popup-body .search-result {
-      padding: 10px;
-    }
-      .markdown-body {
-          padding:15px 10px ;
-    }
-    .loading-warp { 
-      display: none;
-    }
+@media (max-width: 992px) {
+  .main {
+    height: auto;
   }
-  
-  @media (min-width:415px) and (max-width: 1024px) {
-      .main {
-      height: auto;
-    }
-    .main .tea-menu {
-      position: fixed;
-      /* display: none; */
-      left:-250px;
-      z-index: 999;
-      padding-top: 70px;
-    }
-    .main .tea-content {
-      width: 100%;
-      overflow: hidden;
-    }
-    .main .tea-nav {
-      position: fixed;
-      top: 0;
-      left: 0;
-      z-index: 9999;
-    }
-    .main .tea-nav h3 {
-      font-size: 18px !important;
-    }
-    .tea-container {
-      /* height: auto; */
-      padding: 10px 0;
-      box-sizing: border-box;
-      margin-top: 55px;
-    }
-    .main .gotop {
-      left: unset;
-      right: 32px;
-    }
-    #menu-mask {
-      display: none;
-      position: fixed;
-      left: 0;
-      right: 0;
-      top: 0;
-      bottom: 0;
-      margin: auto;
-      z-index: 998;
-      background: rgba(0, 0, 0, 0.5);
-    }
-    .mask .search-popup {
-      width: 100%;
-          height:100%;
-          border-radius: 0;
-    }
-    .mask .search-popup .search-popup-body {
-      max-height: 94%;
-    }
-    .mask .search-popup .search-popup-body .search-result {
-      padding: 0px 10px;
-    }
-      .markdown-body{
-          padding:15px 10px ;
-    }
-    .loading-warp { 
-      display: none;
-    }
+  .main .tea-menu {
+    position: fixed;
+    /* display: none; */
+    left: -250px;
+    z-index: 999;
+    padding-top: 70px;
   }
+  .main .tea-content {
+    width: 100%;
+    overflow: hidden;
+  }
+  .main .tea-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 9999;
+  }
+  .main .tea-nav h3 {
+    font-size: 18px !important;
+  }
+  .tea-container {
+    /* height: auto; */
+    padding: 10px 0;
+    box-sizing: border-box;
+    margin-top: 55px;
+  }
+  .main .gotop {
+    left: unset;
+    right: 32px;
+  }
+  #menu-mask {
+    display: none;
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    margin: auto;
+    z-index: 998;
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .mask .search-popup {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+  .mask .search-popup .search-popup-body {
+    max-height: 94%;
+  }
+  .mask .search-popup .search-popup-body .search-result {
+    padding: 0px 10px;
+  }
+  .markdown-body {
+    padding: 15px 10px;
+  }
+  .loading-warp {
+    display: none;
+  }
+}
+
+@media (max-width: 1200px) {
+  .tea-container .markdown-body {
+    width: 100%;
+  }
+  .tea-container .page {
+    width: 100%;
+  }
+  .tea-container .toc {
+    display: none;
+  }
+}

--- a/lib/themes/default/static/css/style.css
+++ b/lib/themes/default/static/css/style.css
@@ -223,7 +223,7 @@ ul li a {
 }
 
 .tea-container {
-    background-color: rgb(238, 238, 238);
+    background-color: #fff;
     width: 100%;
     height: calc(100vh - 57px);
     overflow-y: auto;
@@ -257,8 +257,9 @@ ul li a {
     padding: 30px 50px;
     box-sizing: border-box;
     min-height: 100%;
-    max-width: 900px;
+    width: calc(100% - 245px);
     box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+    min-height: calc(100% - 81px);
 }
 
 .markdown-body a.header-anchor {
@@ -278,7 +279,7 @@ ul li a {
 }
 
 .page{
-    max-width: 900px;
+    width: calc(100% - 245px);
     box-sizing: border-box;
     padding: 30px 50px;
     background: #fff;
@@ -290,12 +291,52 @@ ul li a {
     border-color: transparent;
     box-shadow: none;
     text-decoration: none;
+    width: 50%;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 .page-prev {
     float: left;
+    text-align: left;
 }
 .page-next {
     float: right;
+    text-align: right;
+}
+
+.toc {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 250px;
+    height: calc(100vh - 61px);
+    margin-top: 57px;
+    overflow: hidden;
+}
+.toc-affix {
+    max-height: calc(100% - 100px);
+    margin: 50px 0;
+    overflow: hidden;
+    padding: 0 40px 0 20px;
+}
+.toc-affix .toc-item {
+    font-size: 12px;
+    list-style: none;
+    border-left: 2px solid #ebedf0;
+    padding: 3px 0;
+}
+.toc-affix .toc-item-active {
+    border-left: 2px solid #009a61;
+    background-color: #ebedf0;
+}
+.toc-affix .toc-item-active a {
+    color: #009a61;
+}
+.toc-affix .text-elli {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .loading-warp {

--- a/lib/themes/default/static/js/main.js
+++ b/lib/themes/default/static/js/main.js
@@ -192,6 +192,7 @@ $(function () {
     });
 
     var tocToggle = function () {
+        if (!$('.toc-affix').find('li').length) return
         const scrollTop = $('.tea-container').scrollTop()
         let items = document.querySelector('.tea-container').querySelectorAll('h1, h2, h3, h4, h5')
         items = Array.prototype.slice.apply(items)
@@ -216,4 +217,18 @@ $(function () {
         const activeId = $(this).attr('data-link')
         $('[data-link=' + activeId + ']').addClass('toc-item-active').siblings().removeClass('toc-item-active')
     })
+
+    $('.tea-menu').find('a').on('click', function (e) {
+        e.preventDefault()
+        const scrollTop = $('.tea-menu').scrollTop()
+        console.log('11 is %o', scrollTop)
+        localStorage.setItem('menuScrollTop', scrollTop)
+        const url = e.currentTarget.href
+        window.location.href = url
+    })
+
+    $('.tea-menu').ready(function(){
+        scrollTop = localStorage.getItem('menuScrollTop') || 0
+        $('.tea-menu').animate({ scrollTop: scrollTop }, 500)
+    });
 });

--- a/lib/themes/default/static/js/main.js
+++ b/lib/themes/default/static/js/main.js
@@ -191,4 +191,29 @@ $(function () {
         }
     });
 
+    var tocToggle = function () {
+        const scrollTop = $('.tea-container').scrollTop()
+        let items = document.querySelector('.tea-container').querySelectorAll('h1, h2, h3, h4, h5')
+        items = Array.prototype.slice.apply(items)
+        let activeId = items[0].id
+        items.some(item => {
+            if (scrollTop > item.offsetTop) {
+                activeId = item.id
+            } else {
+                return true
+            }
+        })
+        $("[data-link=" + activeId + "]").addClass('toc-item-active').siblings().removeClass('toc-item-active')
+    }
+
+    tocToggle()
+
+    // watch mousewheel, 
+    $('.tea-container').on('mousewheel', tocToggle)
+
+    // click acticle catalog item
+    $('.toc-item').on('click', function () {
+        const activeId = $(this).attr('data-link')
+        $('[data-link=' + activeId + ']').addClass('toc-item-active').siblings().removeClass('toc-item-active')
+    })
 });


### PR DESCRIPTION
新增文章分类功能。

### 改动范围

1. 新增文章目录。build.js 生成目录文章的 html，style.css 自定义文章目录样式，main.js 中写了监听事件，处理滚动时目录可以自动切换到对应标题；
2. mobile.css 做了移动端适配，mobile.css 中有很多样式重复，我改写了一下，本地测试都没问题，麻烦看下可有影响；
3. 优化分页。之前只显示 "上一页"、"下一页"，后来看到 pandas 中文网的分页会显示上一页的标题以及下一页的标题，感觉更直观点，做了相应修改；
4. 切换页面，记忆菜单滚动条位置；
5. 本地在浏览器中测了宽屏、手机、Ipad 显示都是正常的

@lisniuse  麻烦本地再测下，以免我哪里有疏漏的地方。如有问题，留言我再改。