### PR TITLE
fix(build.js): 修复增量编译文章标题不显示的Bug

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -210,12 +210,28 @@ class Build {
     }
 
     /**
+     * 全量编译传值：
+     * pathItem = { 
+     *     input: './docs/config/xxx.md', 
+     *     output: './build/config/xxx.html', 
+     *     href: 'config/xxx.html',
+     *     title: '文章标题',
+     *     node: $dom,
+     * }
+     * 
+     * 增量编译传值：
      * pathItem = { 
      *     input: './docs/config/xxx.md', 
      *     output: './build/config/xxx.html', 
      * }
      */
     buildMd (pathItem) {
+        // note: 增量编译调用 buildMd() 不会传文章标题属性(title)，
+        // 需要手动获取完整对象
+        if (!pathItem.title) {
+            pathItem = this._treePaths.find(item => item.input === pathItem.input)
+        }
+        
         // 生成模板文件所需要的所有数据
         this._geneTreeData(pathItem)
         this._geneContentData(pathItem)


### PR DESCRIPTION
## 问题

增量编译调用 buildMd()，值传递了 input 和 output 属性，没有传文章标题属性(title)，导致只要修改完文章，页面标题就会消失的 bug。

## 解决

判断是增量编译时，手动获取完整对象（包含 title 的对象），全量编译不做任何改变。详情见代码~
