### PR TITLE
feat: tree.md 功能优化 (#24)

### DIFF
--- a/bin/teadocs.js
+++ b/bin/teadocs.js
@@ -15,7 +15,7 @@ if (!semver.satisfies(process.version, requiredVersion)) {
 
 // Automatic notification of package updates 
 const updateNotifier = require('update-notifier')
-const pkg = require('./package.json')
+const pkg = require('../package.json')
 const notifier = updateNotifier({pkg})
 notifier.notify()
 

--- a/bin/teadocs.js
+++ b/bin/teadocs.js
@@ -13,6 +13,12 @@ if (!semver.satisfies(process.version, requiredVersion)) {
   process.exit(1)
 }
 
+// Automatic notification of package updates 
+const updateNotifier = require('update-notifier')
+const pkg = require('./package.json')
+const notifier = updateNotifier({pkg})
+notifier.notify()
+
 const path = require('path')
 const dev = require('../lib/dev')
 const build = require('../lib/build')

--- a/lib/config/load.js
+++ b/lib/config/load.js
@@ -6,7 +6,7 @@ const config = require('./config')
 const marked = require('marked')
 const cheerio = require('cheerio')
 
-const parseTree = function (mdTree) {
+const parseTree = function (mdTree, options) {
   let htmlTree = marked(mdTree)
   let $ = cheerio.load(htmlTree, { decodeEntities: false })
   let liEles = $("ul li")
@@ -23,6 +23,15 @@ const parseTree = function (mdTree) {
     if (title[0] === "+") {
       $(elem).children("a").text(title.replace("+", ""))
       $(elem).children("ul").attr("data-show", "1")
+    }
+    // add "$" symbol in tree.md, Indicates that this is a draft and will not be packaged at build.
+    // ref: https://github.com/teadocs/teadocs/issues/24
+    if (title[0] === '$') {
+      if (options.dev) {
+        $(elem).children("a").text(title.replace("$", ""))
+      } else {
+        $(elem).remove()
+      }
     }
   })
   return $("body").html()
@@ -73,7 +82,7 @@ module.exports = function (docsDir, options = {}) {
   }
 
   if (newConfig.nav.tree[0] !== "<") {
-    newConfig.nav.treeHtml = parseTree(utils.readFile(newConfig.nav.tree + ".md"))
+    newConfig.nav.treeHtml = parseTree(utils.readFile(newConfig.nav.tree + ".md"), options)
   }
   let _config = {}
   if (options.dev) {

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -7,6 +7,7 @@ const koaStatic = require('koa-static')
 const open = require("open")
 const chokidar = require('chokidar')
 const cheerio = require('cheerio')
+const detect = require('detect-port')
 
 const utils = require('./utils')
 const build = require('./build')
@@ -28,10 +29,15 @@ class Dev {
     this.buildDir = this.config.doc.outDir
   }
 
-  start() {
+  async start() {
     const app = this._createServe()
-
+    
     const webSocket = this._createWebSocket(app)
+    
+    // Detects if the port is occupied and returns a free port
+    // ref: https://github.com/teadocs/teadocs/issues/25
+    this.port = await detect(this.port)
+    
     webSocket.listen(this.port, this.host, () => {
       console.log('The server is based on ' + this.buildDir + ' directory running on \n' + '[http://' + this.host + ':' + this.port + ']')
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "koa-static": "^5.0.0",
     "marked": "^0.7.0",
     "open": "^7.0.0",
-    "semver": "^6.3.0"
+    "semver": "^6.3.0",
+    "update-notifier": "^3.0.1"
   },
   "engines": {
     "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chokidar": "^3.3.0",
     "co": "^4.6.0",
     "commander": "^4.0.1",
+    "detect-port": "^1.3.0",
     "ejs": "^2.7.1",
     "front-matter": "^3.0.2",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
## 功能

tree.md 添加 `$` 符号，表示这是一篇草稿。
- `teadocs dev` 时仍会显示该篇文章；
- `teadocs build` 时不会打包这篇文章。

e.g.

```
- [介绍](/index)
- +配置介绍
    - [文档目录结构介绍](/config/structure)
- [$部署](/deploy)          <===============
```

注意：`$` 写在文章标题前面，而不是 `[` 前面，类似 `$[部署](/deploy)` 写法是错误的。

## 测试

本地自测 dev  和 build，功能均通过。