### PR TITLE
fix: 修复文件修改,代码块样式丢失的bug (#28)

### DIFF
--- a/lib/client-js/socket.client.js
+++ b/lib/client-js/socket.client.js
@@ -12,6 +12,12 @@
     } else if (pathName === path) {
       container.innerHTML = data.content;
     }
+
+    // bugfix: Modify file, code block style lost
+    // ref: https://github.com/teadocs/teadocs/issues/28
+    document.querySelectorAll('pre code').forEach((block) => {
+      hljs.highlightBlock(block);
+    });
   }
   if ("WebSocket" in window) {
     var socket = io.connect(window.location.host);


### PR DESCRIPTION
## 问题描述

修改 md 文件，增量编译，页面会自动刷新，但是代码块样式会丢失。

## 原因

代码块样式由 [highlight.js](https://highlightjs.org/usage/) 插件完成。

在每次加载页面的时候，都会执行 `hljs.initHighlightingOnLoad(); `，原理是：highlight 会去找代码中所有的 pre 和 code 标签，处理产生高亮。

修改 md 文件，是通过 websocket 将文章内容推送到客户端，只替换 `div.markdown-body` 下面的内容，这造成代码块样式丢失。

## 解决

websocket 每次推送内容后，手动执行找所有的 code 和 pre 元素，然后进行高亮。问题解决~ 

``` js
// socket.client.js
document.querySelectorAll('pre code').forEach((block) => {
      hljs.highlightBlock(block);
});
```